### PR TITLE
Nhse d34 nhskv.i30 lowercase

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -7,7 +7,7 @@
 {cover_enabled, true}.
 {eunit_opts, [verbose, {report,{eunit_surefire,[{dir,"."}]}}]}.
 {profiles, [
-    {test, [{deps, [meck]}]},
+    {test, [{deps, [{meck, {git, "https://github.com/OpenRiak/meck.git", {branch, "openriak-3.2"}}}]}]},
     {gha, [{erl_opts, [{d, 'GITHUBEXCLUDE'}]}]}
 ]}.
 {edoc_opts, [{preprocess, true}]}.

--- a/src/mochifmt.erl
+++ b/src/mochifmt.erl
@@ -314,7 +314,7 @@ convert2(Arg, #conversion{ctype = oct}) ->
 convert2(Arg, #conversion{ctype = upper_hex}) ->
     erlang:integer_to_list(Arg, 16);
 convert2(Arg, #conversion{ctype = hex}) ->
-    string:to_lower(erlang:integer_to_list(Arg, 16));
+    string:lowercase(erlang:integer_to_list(Arg, 16));
 convert2(Arg, #conversion{ctype = char})
     when Arg < 128 ->
     [Arg];

--- a/src/mochiweb_headers.erl
+++ b/src/mochiweb_headers.erl
@@ -26,7 +26,7 @@
 -export([empty/0, from_list/1, insert/3, enter/3, get_value/2, lookup/2]).
 -export([delete_any/2, get_primary_value/2, get_combined_value/2]).
 -export([default/3, enter_from_list/2, default_from_list/2]).
--export([to_list/1, make/1]).
+-export([to_list/1, to_normalised_list/1, make/1]).
 -export([from_binary/1]).
 
 %% @type headers().
@@ -106,6 +106,19 @@ to_list(T) ->
                 [Pair | Acc]
         end,
     lists:reverse(lists:foldl(F, [], gb_trees:values(T))).
+
+%% @spec spec to_normalised_list(headers()) -> [{string(), string()}].
+%% @doc As to_list but all keys are the lowercase (normalised) versions
+to_normalised_list(T) ->
+    F = 
+        fun ({NK, {_K, {array, L}}}, Acc) ->
+            L1 = lists:reverse(L),
+            lists:foldl(fun (V, Acc1) -> [{NK, V} | Acc1] end, Acc, L1);
+        ({NK, {_K, V}}, Acc) ->
+            [{NK, V} | Acc]
+        end,
+    lists:foldl(F, [], gb_trees:to_list(T)).
+    
 
 %% @spec get_value(key(), headers()) -> string() | undefined
 %% @doc Return the value of the given header using a case insensitive search.

--- a/src/mochiweb_headers.erl
+++ b/src/mochiweb_headers.erl
@@ -284,7 +284,7 @@ merge(_, V1, V0) ->
 normalize({normalised, K}) when is_list(K) ->
     K;
 normalize(K) when is_list(K) ->
-    string:to_lower(K);
+    string:lowercase(K);
 normalize(K) when is_atom(K) ->
     normalize(atom_to_list(K));
 normalize(K) when is_binary(K) ->

--- a/src/mochiweb_headers.erl
+++ b/src/mochiweb_headers.erl
@@ -30,7 +30,7 @@
 -export([from_binary/1]).
 
 %% @type headers().
-%% @type key() = atom() | binary() | string().
+%% @type key() = atom() | binary() | string() | {normalised, string()}.
 %% @type value() = atom() | binary() | string() | integer().
 
 %% @spec empty() -> headers()
@@ -268,6 +268,8 @@ merge("set-cookie", V1, V0) ->
 merge(_, V1, V0) ->
     V0 ++ ", " ++ V1.
 
+normalize({normalised, K}) when is_list(K) ->
+    K;
 normalize(K) when is_list(K) ->
     string:to_lower(K);
 normalize(K) when is_atom(K) ->

--- a/src/mochiweb_html.erl
+++ b/src/mochiweb_html.erl
@@ -314,7 +314,7 @@ tokens(B, S=#decoder{offset=O}, Acc) ->
     end.
 
 parse_flag({start_tag, B, _, false}) ->
-    case string:to_lower(binary_to_list(B)) of
+    case string:lowercase(binary_to_list(B)) of
         "script" ->
             script;
         "textarea" ->
@@ -403,7 +403,7 @@ norm({Tag, Attrs}) ->
 norm(Tag) when is_binary(Tag) ->
     Tag;
 norm(Tag) ->
-    list_to_binary(string:to_lower(Tag)).
+    list_to_binary(string:lowercase(Tag)).
 
 stack(T1={TN, _, _}, Stack=[{TN, _, _} | _Rest])
   when TN =:= <<"li">> orelse TN =:= <<"option">> ->
@@ -594,7 +594,7 @@ tokenize_literal(Bin, S=#decoder{offset=O}, Acc) ->
                                               orelse C =:= $=) ->
             tokenize_literal(Bin, ?INC_COL(S), [C | Acc]);
         _ ->
-            {iolist_to_binary(string:to_lower(lists:reverse(Acc))), S}
+            {iolist_to_binary(string:lowercase(lists:reverse(Acc))), S}
     end.
 
 raw_qgt(Bin, S=#decoder{offset=O}) ->

--- a/src/mochiweb_multipart.erl
+++ b/src/mochiweb_multipart.erl
@@ -204,7 +204,7 @@ split_header(Line) ->
 						   C =/= $:
 					   end,
 					   binary_to_list(Line)),
-    {string:to_lower(string:strip(Name)),
+    {string:lowercase(string:trim(Name)),
      mochiweb_util:parse_header(Value)}.
 
 read_chunk({ReqM, _} = Req, Length) when Length > 0 ->
@@ -590,7 +590,7 @@ parse_partial_body_boundary_https_test() ->
     parse_partial_body_boundary(ssl).
 
 parse_partial_body_boundary(Transport) ->
-    Boundary = string:copies("$", 2048),
+    Boundary = lists:concat(lists:duplicate(2048, "$")),
     ContentType = "multipart/form-data; boundary=" ++
 		    Boundary,
     ?assertEqual(Boundary, (get_boundary(ContentType))),
@@ -650,7 +650,7 @@ parse_large_header(Transport) ->
 				    ++ "filename=\"file1.txt\"",
 				  "Content-Type: text/plain",
 				  "x-large-header: " ++
-				    string:copies("%", 4096),
+				    lists:concat(lists:duplicate(4096, "%")),
 				  "", "... contents of file1.txt ...",
 				  "--AaB03x--", ""],
 				 "\r\n"),
@@ -664,7 +664,7 @@ parse_large_header(Transport) ->
 		 {"form-data",
 		  [{"name", "files"}, {"filename", "file1.txt"}]}},
 		{"content-type", {"text/plain", []}},
-		{"x-large-header", {string:copies("%", 4096), []}}]},
+		{"x-large-header", {lists:concat(lists:duplicate(4096, "%")), []}}]},
 	      {body, <<"... contents of file1.txt ...">>}, body_end,
 	      eof],
     TestCallback = fun (Next) -> test_callback(Next, Expect)
@@ -793,7 +793,7 @@ flash_parse2(Transport) ->
 	"3GI3Ij5Ef1ae0KM7Ij5ei4Ij5",
     "----------ei4GI3GI3Ij5Ef1ae0KM7Ij5ei4Ij5" =
 	get_boundary(ContentType),
-    Chunk = iolist_to_binary(string:copies("%", 4096)),
+    Chunk = iolist_to_binary(lists:concat(lists:duplicate(4096, "%"))),
     BinContent =
 	<<"------------ei4GI3GI3Ij5Ef1ae0KM7Ij5ei4Ij5\r\n"
 	  "Content-Disposition: form-data; name=\"Filena"

--- a/src/mochiweb_request.erl
+++ b/src/mochiweb_request.erl
@@ -172,7 +172,7 @@ get(peer,
 	  case get_header_value("x-forwarded-for", THIS) of
 	    undefined -> inet_parse:ntoa(Addr);
 	    Hosts ->
-		string:strip(lists:last(string:tokens(Hosts, ",")))
+		string:trim(lists:last(string:lexemes(Hosts, ",")))
 	  end;
       %% Copied this syntax from webmachine contributor Steve Vinoski
       {ok, {Addr = {172, Second, _, _}, _Port}}
@@ -180,7 +180,7 @@ get(peer,
 	  case get_header_value("x-forwarded-for", THIS) of
 	    undefined -> inet_parse:ntoa(Addr);
 	    Hosts ->
-		string:strip(lists:last(string:tokens(Hosts, ",")))
+		string:trim(lists:last(string:lexemes(Hosts, ",")))
 	  end;
       %% According to RFC 6598, contributor Gerald Xv
       {ok, {Addr = {100, Second, _, _}, _Port}}
@@ -188,19 +188,19 @@ get(peer,
 	  case get_header_value("x-forwarded-for", THIS) of
 	    undefined -> inet_parse:ntoa(Addr);
 	    Hosts ->
-		string:strip(lists:last(string:tokens(Hosts, ",")))
+		string:trim(lists:last(string:lexemes(Hosts, ",")))
 	  end;
       {ok, {Addr = {192, 168, _, _}, _Port}} ->
 	  case get_header_value("x-forwarded-for", THIS) of
 	    undefined -> inet_parse:ntoa(Addr);
 	    Hosts ->
-		string:strip(lists:last(string:tokens(Hosts, ",")))
+		string:trim(lists:last(string:lexemes(Hosts, ",")))
 	  end;
       {ok, {{127, 0, 0, 1}, _Port}} ->
 	  case get_header_value("x-forwarded-for", THIS) of
 	    undefined -> "127.0.0.1";
 	    Hosts ->
-		string:strip(lists:last(string:tokens(Hosts, ",")))
+		string:trim(lists:last(string:lexemes(Hosts, ",")))
 	  end;
       {ok, {Addr, _Port}} -> inet_parse:ntoa(Addr);
       {error, enotconn = Error} -> exit({shutdown, Error})
@@ -357,7 +357,7 @@ stream_body(MaxChunkSize, ChunkFun, FunState,
 		THIS) ->
     Expect = case get_header_value("expect", THIS) of
 	       undefined -> undefined;
-	       Value when is_list(Value) -> string:to_lower(Value)
+	       Value when is_list(Value) -> string:lowercase(Value)
 	     end,
     case Expect of
       "100-continue" ->
@@ -631,7 +631,7 @@ should_close({?MODULE,
 
 is_close("close") -> true;
 is_close(S = [_C, _L, _O, _S, _E]) ->
-    string:to_lower(S) =:= "close";
+    string:lowercase(S) =:= "close";
 is_close(_) -> false.
 
 %% @spec cleanup(request()) -> ok
@@ -877,7 +877,7 @@ maybe_redirect(RelPath, FullPath, ExtraHeaders,
 		[_Socket, _Opts, _Method, _RawPath, _Version,
 		 Headers]} =
 		   THIS) ->
-    case string:right(RelPath, 1) of
+    case string:pad(RelPath, 1) of
       "/" ->
 	  maybe_serve_file(directory_index(FullPath),
 			   ExtraHeaders, THIS);
@@ -1052,7 +1052,7 @@ accepts_content_type(ContentType1,
     case mochiweb_util:parse_qvalues(AcceptHeader) of
       invalid_qvalue_string -> bad_accept_header;
       QList ->
-	  [MainType, _SubType] = string:tokens(ContentType, "/"),
+	  [MainType, _SubType] = string:lexemes(ContentType, "/"),
 	  SuperType = MainType ++ "/*",
 	  lists:any(fun ({"*/*", Q}) when Q > 0.0 -> true;
 			({Type, Q}) when Q > 0.0 ->
@@ -1105,7 +1105,7 @@ accepted_content_types(Types1,
 				       case proplists:get_value(T, QList) of
 					 undefined ->
 					     [MainType, _SubType] =
-						 string:tokens(T, "/"),
+						 string:lexemes(T, "/"),
 					     case proplists:get_value(MainType
 									++ "/*",
 								      QList)

--- a/test/mochiweb_html_tests.erl
+++ b/test/mochiweb_html_tests.erl
@@ -232,7 +232,7 @@ tokenize_attributes_test() ->
        {<<"foo">>,
         [{<<"bar">>, <<"b\"az">>},
          {<<"wibble">>, <<"wibble">>},
-         {<<"taco", 16#c2, 16#a9>>, <<"bell">>},
+         {<<"taco©">>, <<"bell">>},
          {<<"quux">>, <<"quux">>}],
         []},
        mochiweb_html:parse(<<"<foo bar=\"b&quot;az\" wibble taco&copy;=bell quux">>)),


### PR DESCRIPTION
Management of headers previously required continuous re-normalisation (i.e. lower-casing) of the header keys.

This includes a new function `to_normalised_list/1`, which returns a list of request headers with the keys being the lower-cased string-version of the keys - so they don't need to be re-normalised before matching. 

It is now also possible to pass in `{normalised, K}` instead of 'K' to functions to bypass normalisation, where the calling application has already lowercased the string.

This list can then be returned to applications for direct matching of headers, rather than entering into `wrq:get_req_hader/2` -> `mochiweb_headers:get_value/2` -> `mochiweb_headers:lookup/2` loop which requires the keys to bw re-normalised.  This also allows the calling application to create a map from the list, rather than being tide to using gb_trees.

As part of this change, the deprecated string functions have been replaced to instead use the new post-OTP 20 functions